### PR TITLE
Added copying of pan info to AVPro audio sources

### DIFF
--- a/Packages/com.texelsaur.video/Editor/VideoComponentUpdater.cs
+++ b/Packages/com.texelsaur.video/Editor/VideoComponentUpdater.cs
@@ -466,6 +466,7 @@ namespace Texel
                             targetAudioSource.enabled = false;
                             targetAudioSource.volume = sourceAudioSource.volume;
                             targetAudioSource.spatialBlend = sourceAudioSource.spatialBlend;
+                            targetAudioSource.panStereo = sourceAudioSource.panStereo;
                             targetAudioSource.spread = sourceAudioSource.spread;
                             targetAudioSource.minDistance = sourceAudioSource.minDistance;
                             targetAudioSource.maxDistance = sourceAudioSource.maxDistance;


### PR DESCRIPTION
Allowed AVPro audio sources to copy stereo pan for simulated global stereo mix on non-standard channels.

This is so we can have channel 3 + 4 as a fake global stereo, to allow for channel mixing shenanigans for isolating sources between twitch streaming vs VRCDN streaming with minimal components in the middle.

The setup here is to set the stereo pan left/right of channel 3 and 4 to -1 and 1 respectively, with otherwise identical setup to the "Global" prefab. This way we get global audio on non-standard channels.

This PR enables this behavior by copying over pan information to the audio source.